### PR TITLE
fix: ICE failure in development

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
+		"dev": "vite --host",
 		"build": "tsc -b && vite build",
 		"lint": "eslint .",
 		"preview": "vite preview"


### PR DESCRIPTION
When running the vite development server on loopback address Firefox clients fail to establish peer-to-peer connection.
ICE negotiation fails with a generic error message: `WebRTC: ICE failed, add a TURN server and see about:webrtc for more details`.

Possibly related: https://bugzilla.mozilla.org/show_bug.cgi?id=1659672