### PR TITLE
feat: delay the removal of empty rooms to allow reconnection

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -13,11 +13,11 @@ import (
 
 type SignalHandler struct {
 	users    *UserService
-	rooms    *RoomStore
+	rooms    *RoomService
 	upgrader websocket.Upgrader
 }
 
-func NewSignalHandler(origins string, us *UserService, rs *RoomStore) *SignalHandler {
+func NewSignalHandler(origins string, us *UserService, rs *RoomService) *SignalHandler {
 	return &SignalHandler{
 		users: us,
 		rooms: rs,
@@ -102,42 +102,26 @@ func (sh *SignalHandler) disconnect(u *User) error {
 		return nil
 	}
 
-	room, err := sh.rooms.Get(u.roomID)
+	roomID := u.roomID
+	room, err := sh.rooms.RemoveUser(roomID, u)
 	if err != nil {
-		return err
-	}
-	room.RemoveUser(u)
-	// close the room if hosting
-	if room.Host == u.ID {
-		room.ForEachUser(func(user *User) {
-			user.roomID = ""
-			if err := user.send(Message{
-				Type:    SignalRoomLeft,
-				Payload: room,
-			}); err != nil {
-				log.Printf("write json: %v", err)
-			}
-		})
-		sh.rooms.Delete(room.ID)
-		return nil
-	}
-
-	if len(room.Users) == 0 {
+		if !errors.Is(err, ErrRoomNotFound) {
+			return err
+		}
 		return nil
 	}
 
 	if err := sh.broadcast(u.conn, Message{
 		Type:    SignalUserLeft,
 		Payload: u,
-	}, room.ID); err != nil {
+	}, roomID); err != nil {
 		return fmt.Errorf("broadcast user-left: %v", err)
 	}
 
-	err = sh.broadcast(u.conn, Message{
+	if err := sh.broadcast(u.conn, Message{
 		Type:    SignalRoomInfo,
 		Payload: room,
-	}, room.ID)
-	if err != nil {
+	}, roomID); err != nil {
 		return fmt.Errorf("broadcast room-info: %v", err)
 	}
 
@@ -209,7 +193,7 @@ func (sh *SignalHandler) handleInviteToRoom(u *User, msg Message) error {
 }
 
 func (sh *SignalHandler) handleCreateRoom(u *User, msg Message) error {
-	room, err := sh.rooms.Create(u.ID)
+	room, err := sh.rooms.Create()
 	if err != nil {
 		return u.send(Message{
 			Transaction: msg.Transaction,
@@ -290,10 +274,14 @@ func (sh *SignalHandler) handleJoinRoom(u *User, msg Message) error {
 		return err
 	}
 
-	return sh.broadcast(u.conn, Message{
+	if err := sh.broadcast(u.conn, Message{
 		Type:    SignalUserJoined,
 		Payload: u,
-	}, room.ID)
+	}, room.ID); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (sh *SignalHandler) handleLeaveRoom(u *User, msg Message) error {
@@ -306,7 +294,7 @@ func (sh *SignalHandler) handleLeaveRoom(u *User, msg Message) error {
 		return u.send(createErrorResponse(msg, ErrCodeBadRequest, "Bad request"))
 	}
 
-	room, err := sh.rooms.Get(payload.RoomID)
+	room, err := sh.rooms.RemoveUser(payload.RoomID, u)
 	if err != nil {
 		if errors.Is(err, ErrRoomNotFound) {
 			return u.send(Message{
@@ -321,28 +309,12 @@ func (sh *SignalHandler) handleLeaveRoom(u *User, msg Message) error {
 		return err
 	}
 
-	room.RemoveUser(u)
 	if err := u.send(Message{
 		Transaction: msg.Transaction,
 		Type:        SignalRoomLeft,
 		Payload:     room,
 	}); err != nil {
 		return err
-	}
-
-	if room.Host == u.ID {
-		room.ForEachUser(func(user *User) {
-			user.roomID = ""
-			err := user.send(Message{
-				Type:    SignalRoomLeft,
-				Payload: room,
-			})
-			if err != nil {
-				log.Printf("write json: %v", err)
-			}
-		})
-		sh.rooms.Delete(room.ID)
-		return nil
 	}
 
 	if err := sh.broadcast(u.conn, Message{

--- a/backend/main.go
+++ b/backend/main.go
@@ -11,7 +11,11 @@ import (
 
 func main() {
 	origins := os.Getenv("ALLOWED_ORIGINS")
-	sh := NewSignalHandler(origins, NewUserService(), NewRoomStore())
+	sh := NewSignalHandler(
+		origins,
+		NewUserService(),
+		NewRoomService(NewRoomStore()),
+	)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/socket", func(w http.ResponseWriter, r *http.Request) {

--- a/backend/room.go
+++ b/backend/room.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-
-	"github.com/google/uuid"
+	"time"
 )
 
 type Room struct {
 	ID    string       `json:"id"`
 	mu    sync.RWMutex `json:"-"`
-	Host  uuid.UUID    `json:"host"`
 	Users []*User      `json:"users"`
 }
 
@@ -69,7 +67,7 @@ func (s *RoomStore) Get(id string) (*Room, error) {
 	return room, nil
 }
 
-func (s *RoomStore) Create(host uuid.UUID) (*Room, error) {
+func (s *RoomStore) Create() (*Room, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -81,10 +79,7 @@ func (s *RoomStore) Create(host uuid.UUID) (*Room, error) {
 		return nil, fmt.Errorf("duplicate room id")
 	}
 
-	room := &Room{
-		ID:   id,
-		Host: host,
-	}
+	room := &Room{ID: id}
 	s.rooms[id] = room
 	return room, nil
 }
@@ -107,6 +102,94 @@ func (s *RoomStore) Delete(id string) {
 	defer s.mu.Unlock()
 
 	delete(s.rooms, id)
+}
+
+type RoomService struct {
+	store  *RoomStore
+	timers map[string]*time.Timer
+	mu     sync.Mutex
+}
+
+func NewRoomService(store *RoomStore) *RoomService {
+	return &RoomService{
+		store:  store,
+		timers: make(map[string]*time.Timer),
+	}
+}
+
+func (s *RoomService) Get(id string) (*Room, error) {
+	return s.store.Get(id)
+}
+
+func (s *RoomService) Create() (*Room, error) {
+	room, err := s.store.Create()
+	if err != nil {
+		return nil, err
+	}
+
+	s.startDeleteTimer(room.ID)
+
+	return room, err
+}
+
+func (s *RoomService) Delete(id string) {
+	s.stopDeleteTimer(id)
+	s.store.Delete(id)
+}
+
+func (s *RoomService) AddUser(roomID string, u *User) (*Room, error) {
+	room, err := s.store.Get(roomID)
+	if err != nil {
+		return nil, err
+	}
+
+	room.AddUser(u)
+	s.stopDeleteTimer(roomID)
+
+	return room, nil
+}
+
+func (s *RoomService) RemoveUser(roomID string, u *User) (*Room, error) {
+	room, err := s.store.Get(roomID)
+	if err != nil {
+		return nil, err
+	}
+
+	room.RemoveUser(u)
+	if len(room.Users) == 0 {
+		s.startDeleteTimer(roomID)
+	}
+
+	return room, nil
+}
+
+func (s *RoomService) startDeleteTimer(roomID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	timer := time.AfterFunc(60*time.Second, func() {
+		defer s.stopDeleteTimer(roomID)
+		room, err := s.store.Get(roomID)
+		if err != nil {
+			return
+		}
+		if len(room.Users) == 0 {
+			s.Delete(room.ID)
+		}
+	})
+
+	s.timers[roomID] = timer
+}
+
+func (s *RoomService) stopDeleteTimer(roomID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	timer, ok := s.timers[roomID]
+	if ok {
+		timer.Stop()
+		delete(s.timers, roomID)
+	}
 }
 
 const (

--- a/frontend/src/lib/schemas/room.ts
+++ b/frontend/src/lib/schemas/room.ts
@@ -3,7 +3,6 @@ import { UserSchema } from "./user";
 
 export const RoomSchema = z.object({
 	id: z.string(),
-	host: z.optional(z.string()),
 	users: z.optional(z.union([z.array(UserSchema), z.null()])),
 });
 


### PR DESCRIPTION
The way rooms are handled is a bit problematic in some scenarios, especially on mobile.
If a mobile user creates a room, copies the room link and opens another app in order to send it to someone, they'll most likely find out that the room had been closed once they return to the page.