### PR TITLE
fix: prevent zombie websocket connections

### DIFF
--- a/frontend/src/hooks/use-notifications.tsx
+++ b/frontend/src/hooks/use-notifications.tsx
@@ -1,13 +1,12 @@
 import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "react-toastify";
-import { getServer, type ServerEventMap } from "#/lib/server";
+import { server, type ServerEventMap } from "#/lib/server";
 import { InviteNotification } from "#/components/toast";
 
 export function useNotifications() {
 	const navigate = useNavigate();
 	useEffect(() => {
-		const server = getServer();
 		const handler = (e: ServerEventMap["room-invitation"]) => {
 			toast(<InviteNotification invitation={e.detail} />, {
 				autoClose: false,

--- a/frontend/src/lib/room.ts
+++ b/frontend/src/lib/room.ts
@@ -50,7 +50,12 @@ export async function joinRoom(
 
 export async function leaveRoom(server: SignalingServer) {
 	const room = $room.get();
-	if (!room) return;
+	if (
+		!room ||
+		(server.state !== "connected" && server.state !== "connecting")
+	) {
+		return;
+	}
 	try {
 		await server
 			.request({

--- a/frontend/src/lib/server.ts
+++ b/frontend/src/lib/server.ts
@@ -51,7 +51,10 @@ export type ServerEventMap = {
 
 type ServerEvent = ServerEventMap[keyof ServerEventMap];
 
+type ConnectionState = ReturnType<typeof $connectionState.get>;
+
 export class SignalingServer extends TypedEventTarget<ServerEventMap> {
+	state: ConnectionState = "disconnected";
 	#url: string;
 	#ws: WebSocket | undefined = undefined;
 	#currentID: number = 0;
@@ -65,7 +68,7 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 	constructor(url: string) {
 		super();
 		this.#url = url;
-		$connectionState.set("connecting");
+		this.#setState("connecting");
 		this.#ws = this.#createSocket();
 	}
 
@@ -79,6 +82,11 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 		this.#ws.addEventListener("open", () => this.startKeepAlive());
 		this.#ws.addEventListener("close", () => this.stopKeepAlive());
 		return this.#ws;
+	}
+
+	#setState(v: ConnectionState) {
+		this.state = v;
+		$connectionState.set(v);
 	}
 
 	async connect(): Promise<WebSocket> {
@@ -100,7 +108,7 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 		}
 
 		try {
-			$connectionState.set("connecting");
+			this.#setState("connecting");
 			this.#ws = this.#createSocket();
 
 			this.#reconnectAttempts = 0;
@@ -111,7 +119,7 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 			await waitForOpen(this.#ws);
 			return this.#ws;
 		} catch (err) {
-			$connectionState.set("failed");
+			this.#setState("failed");
 			throw err;
 		}
 	}
@@ -137,6 +145,7 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 	}
 
 	destroy() {
+		this.state = "disconnected";
 		this.#destroyed = true;
 		clearTimeout(this.#reconnectTimeout);
 		this.#reconnectTimeout = undefined;
@@ -197,16 +206,16 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 	}
 
 	#onerror = (e: Event) => {
-		$connectionState.set("failed");
+		this.#setState("failed");
 		console.error("WebSocket error: " + JSON.stringify(e));
 	};
 
 	#onopen = () => {
-		$connectionState.set("connected");
+		this.#setState("connected");
 	};
 
 	#onclose = () => {
-		$connectionState.set("disconnected");
+		this.#setState("disconnected");
 		$identity.set(undefined);
 		removeConnections();
 		closeRoom();

--- a/frontend/src/lib/server.ts
+++ b/frontend/src/lib/server.ts
@@ -90,6 +90,9 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 	}
 
 	async connect(): Promise<WebSocket> {
+		if (this.#destroyed) {
+			throw new Error("instance has been destroyed");
+		}
 		if (this.#ws?.readyState === WebSocket.OPEN) {
 			return this.#ws;
 		}
@@ -164,6 +167,9 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 			{ type: keyof typeof RequestResponseMap }
 		>,
 	>(msg: Req): Promise<ResponseMap[Req["type"]]> {
+		if (this.#destroyed) {
+			throw new Error("instance has been destroyed");
+		}
 		const ws = await this.connect();
 
 		this.#currentID++;
@@ -201,6 +207,9 @@ export class SignalingServer extends TypedEventTarget<ServerEventMap> {
 	}
 
 	async send(msg: OutgoingMessage) {
+		if (this.#destroyed) {
+			throw new Error("instance has been destroyed");
+		}
 		const ws = await this.connect();
 		ws.send(JSON.stringify(msg));
 	}

--- a/frontend/src/lib/server.ts
+++ b/frontend/src/lib/server.ts
@@ -337,7 +337,7 @@ function resolveSocketURL(): string {
 
 let instance: SignalingServer | undefined;
 
-export function getServer(): SignalingServer {
+function getServer(): SignalingServer {
 	if (!instance) {
 		window.__WEBSEND_SERVER?.destroy();
 		instance = new SignalingServer(resolveSocketURL());
@@ -345,3 +345,5 @@ export function getServer(): SignalingServer {
 	}
 	return instance;
 }
+
+export const server = getServer();

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "#/components/icons";
 import { toast } from "react-toastify";
 import { createRoom } from "#/lib/room";
-import { getServer } from "#/lib/server";
+import { server } from "#/lib/server";
 import { useNotifications } from "#/hooks/use-notifications";
 
 export const Route = createFileRoute("/")({
@@ -28,7 +28,7 @@ function Component() {
 	async function handleCreate() {
 		setCreating(true);
 		try {
-			const { id } = await createRoom(getServer());
+			const { id } = await createRoom(server);
 			navigate({ to: "/r/$id", params: { id } });
 		} catch (err) {
 			console.error("create room:", err);

--- a/frontend/src/routes/r/$id.tsx
+++ b/frontend/src/routes/r/$id.tsx
@@ -24,7 +24,7 @@ import { FileArea } from "#/components/filearea";
 import { Heading } from "#/components/ui/heading";
 import type { Room, User } from "#/lib/schemas";
 import { Dialog, DialogContent } from "#/components/ui/dialog";
-import { getServer } from "#/lib/server";
+import { server } from "#/lib/server";
 import { joinRoom, leaveRoom, roomState } from "#/lib/room";
 import { useResult } from "#/hooks/hooks";
 import { useNotifications } from "#/hooks/use-notifications";
@@ -44,13 +44,13 @@ function Component() {
 	const peers = useStore($peers);
 	useNotifications();
 	const { status, error } = useResult(
-		() => joinRoom(getServer(), id),
+		() => joinRoom(server, id),
 		identity === undefined,
 	);
 	useEffect(() => {
 		return () => {
 			if (roomState() === "active") {
-				leaveRoom(getServer());
+				leaveRoom(server);
 			}
 		};
 	}, []);
@@ -147,7 +147,7 @@ function RoomInfo({
 	}
 
 	function inviteUser(id: string) {
-		getServer().send({
+		server.send({
 			type: "invite-to-room",
 			payload: { user_id: id, room_id: room.id },
 		});


### PR DESCRIPTION
Resolve an issue where under some circumstances you could end up with zombie connections in development
after Vite reloads lib/server.ts.