### PR TITLE
fix: native-file-system-adapter downloads being incorrectly saved as HTML on iOS Safari

### DIFF
--- a/frontend/src/lib/native-file-system-adapter/adapters/downloader.js
+++ b/frontend/src/lib/native-file-system-adapter/adapters/downloader.js
@@ -62,6 +62,7 @@ export class FileHandle {
 			const headers = {
 				"content-disposition": "attachment; filename*=UTF-8''" + fileName,
 				"content-type": "application/octet-stream; charset=utf-8",
+				"X-Content-Type-Options": "nosniff",
 				...(options.size ? { "content-length": String(options.size) } : {}),
 			};
 


### PR DESCRIPTION
Patch native-file-system-adapter to prevent iOS Safari from incorrectly detecting and saving download streams as HTML.